### PR TITLE
Updated CocoaLumberjack import

### DIFF
--- a/Source/CrashlyticsLogger.h
+++ b/Source/CrashlyticsLogger.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2013 TechSmith. All rights reserved.
 //
 
-#import <CocoaLumberjack/DDLog.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 @interface CrashlyticsLogger : DDAbstractLogger
 


### PR DESCRIPTION
You are currently importing the old header, which leads to redefinition warnings if the new header is imported somewhere else
